### PR TITLE
Add custom properties and fix `display`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Begin adding custom properties
+- Add `@properties` via `properties.js`
+- Add theme inheritance via `:host-context()` (where supported)
+
+### Fixed
+- Do not set `display` for `hidden` or `popover` elements
+
 ## [v0.1.2] - 2024-09-19
 
 ### Changed

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,3 @@
-import { ignoreFile } from '@shgysk8zer0/eslint-config/ignoreFile.js';
 import browser from '@shgysk8zer0/eslint-config/browser.js';
 
-export default [ignoreFile, browser()];
+export default browser({files: ['**/*.js'] });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aegisjsproject/styles",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@aegisjsproject/styles",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aegisjsproject/styles",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Pre-made and reusable styles for `@aegisjsproject/core`",
   "keywords": [
     "aegis",

--- a/properties.js
+++ b/properties.js
@@ -1,0 +1,26 @@
+import { light, dark } from './palette/bootstrap.js';
+import { css } from '@aegisjsproject/core/parsers/css.js';
+
+export const properties = css`@property --aegis-color-light {
+	syntax: "<color>";
+	inherits: true;
+	initial-value: ${dark};
+  }
+
+  @property --aegis-color-dark {
+	syntax: "<color>";
+	inherits: true;
+	initial-value: ${light};
+  }
+
+  @property --aegis-bg-light {
+	syntax: "<color>";
+	inherits: true;
+	initial-value: ${light};
+  }
+
+  @property --aegis-bg-dark {
+	syntax: "<color>";
+	inherits: true;
+	initial-value: ${dark};
+  }`;

--- a/styles.js
+++ b/styles.js
@@ -3,7 +3,5 @@ export * as gnome from './palette/gnome.js';
 export { btn } from './button.js';
 export { reset } from './reset.js';
 export { sheetToFile, sheetToLink } from './utils.js';
-export {
-	baseTheme, darkTheme, lightTheme, componentBase, componentDarkTheme,
-	componentLightTheme,
-} from  './theme.js';
+export * from './properties.js';
+export * from  './theme.js';

--- a/test/index.html
+++ b/test/index.html
@@ -31,6 +31,12 @@
 	</head>
 	<body>
 		<button type="button" id="toggle" class="btn btn-primary">Toggle Theme</button>
+		<button type="button" popovertarget="popover" popovertargetaction="toggle" class="btn btn-primary">Toggle Popover</button>
 		<p>The Current Theme is: <span id="cur">auto</span>.</p>
+		<test-el popover="auto" id="popover"></test-el>
+		<test-el></test-el>
+		<test-el theme="light"></test-el>
+		<test-el theme="dark"></test-el>
+		<test-el hidden=""></test-el>
 	</body>
 </html>

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
-import { btn, reset, baseTheme, darkTheme, lightTheme } from '@aegisjsproject/styles';
-import { addStyles } from '@aegisjsproject/core';
+import { btn, reset, baseTheme, darkTheme, lightTheme, componentBase, componentDarkTheme, componentLightTheme, properties, bootstrap } from '@aegisjsproject/styles';
+import { addStyles, css } from '@aegisjsproject/core';
 
-addStyles(document, btn, reset, baseTheme, darkTheme, lightTheme);
+addStyles(document, properties, btn, reset, baseTheme, darkTheme, lightTheme);
 
 document.getElementById('toggle').addEventListener('click', async () => {
 	switch(document.documentElement.dataset.theme) {
@@ -32,5 +32,31 @@ cookieStore.get('theme').then(cookie => {
 	if (typeof cookie?.value === 'string') {
 		document.documentElement.dataset.theme = cookie.value;
 		document.getElementById('cur').textContent = document.documentElement.dataset.theme;
+	}
+});
+
+customElements.define('test-el', class TestElement extends HTMLElement {
+	#shadow;
+
+	constructor() {
+		super();
+		this.#shadow = this.attachShadow({ mode: 'closed' });
+	}
+
+	connectedCallback() {
+		const slot = document.createElement('slot');
+		slot.name = 'content';
+		slot.textContent = 'Hello, World!';
+		this.#shadow.adoptedStyleSheets = [
+			componentBase, componentDarkTheme, componentLightTheme, btn, reset,
+			css`:host {
+				padding: 0.7em 0.3em;
+				border: 1px solid ${bootstrap.gray[5]};
+				border-radius: 8px;
+				width: max-content;
+				margin: 8px;
+			}`
+		];
+		this.#shadow.append(slot);
 	}
 });

--- a/theme.js
+++ b/theme.js
@@ -3,59 +3,80 @@ import { css, darkCSS, lightCSS } from '@aegisjsproject/core/parsers/css.js';
 
 export const baseTheme = css`:root {
 	color-scheme: light dark;
-	color: ${dark};
-	background-color: ${light};
+	color: var(--aegis-color-light, ${dark});
+	background-color: var(--aegis-bg-light, ${light});
 	font-family: system-ui;
 }
 
 :root[data-theme="light"] {
 	color-scheme: light;
-	color: ${dark};
-	background-color: ${light};
+	color: var(--aegis-color-light, ${dark});
+	background-color: var(--aegis-bg-light, ${light});
 }
 
 :root[data-theme="dark"] {
 	color-scheme: dark;
-	color: ${light};
-	background-color: ${dark};
+	color: var(--aegis-color-dark, ${light});
+	background-color: var(--aegis-bg-dark, ${dark});
 }`;
 
 export const darkTheme = darkCSS`:root:not([data-theme="light"]) {
-	color: ${light};
-	background-color: ${dark};
+	color: var(--aegis-color-dark, ${light});
+	background-color: var(--aegis-bg-dark, ${dark});
 }`;
 
 export const lightTheme = lightCSS`:root:not([data-theme="dark"]) {
-	color: ${dark};
-	background-color: ${light};
+	color: var(--aegis-color-light, ${dark});
+	background-color: var(--aegis-bg-light, ${light});
 }`;
 
 export const componentBase = css`:host {
-	display: block;
 	color-scheme: light dark;
-	color: ${dark};
-	background-color: ${light};
+	color: var(--aegis-color-light, ${dark});
+	background-color: var(--aegis-bg-light, ${light});
 	font-family: system-ui;
+}
+
+/*:host(:not([popover])) {
+	display: block;
+}*/
+
+:host(:not([hidden]):not([popover])) {
+	display: block;
+}
+
+:host-context([data-theme="light"]):host(:not([theme="dark"])) {
+	color-scheme: light;
+	color: var(--aegis-color-light, ${dark});
+	background-color: var(--aegis-bg-light, ${light});
+}
+
+:host-context([data-theme="dark"]):host(:not([theme="light"])) {
+	color-scheme: dark;
+	color: var(--aegis-color-dark, ${light});
+	background-color: var(--aegis-bg-dark, ${dark});
 }
 
 :host([theme="light"]) {
 	color-scheme: light;
+	color: var(--aegis-color-light, ${dark});
+	background-color: var(--aegis-bg-light, ${light});
 }
 
 :host([theme="dark"]) {
 	color-scheme: dark;
-	color: ${light};
-	background-color: ${dark};
+	color: var(--aegis-color-dark, ${light});
+	background-color: var(--aegis-bg-dark, ${dark});
 }`;
 
 export const componentDarkTheme = darkCSS`:host(:not([theme="light"])) {
 	color-scheme: dark;
-	color: ${light};
-	background-color: ${dark};
+	color: var(--aegis-color-dark, ${light});
+	background-color: var(--aegis-bg-dark, ${dark});
 }`;
 
 export const componentLightTheme = lightCSS`:host(:not([theme="dark"])) {
 	color-scheme: light;
-	color: ${dark};
-	background-color: ${light};
+	color: var(--aegis-color-light, ${light});
+	background-color: var(--aegis-bg-light, ${dark});
 }`;


### PR DESCRIPTION
### Added
- Begin adding custom properties
- Add `@properties` via `properties.js`
- Add theme inheritance via `:host-context()` (where supported)

### Fixed
- Do not set `display` for `hidden` or `popover` elements

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
